### PR TITLE
Refactor approximateNow.ts

### DIFF
--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -4,18 +4,18 @@ let now = ms * Math.ceil(Date.now() / ms);
 let maxNow = ms * Math.ceil((now + ms) / ms);
 
 const approximateTime = {
-    get now () {
-      if (now < maxNow) {
-        return now++;
-      }
+  get now () {
+    if (now < maxNow) {
+      return now++;
+    }
 
-      return maxNow;
-    },
-    set now (nextNow) {
-      now = nextNow;
-      maxNow = ms * Math.ceil((now + ms) / ms);
-    },
-  };
+    return maxNow;
+  },
+  set now (nextNow) {
+    now = nextNow;
+    maxNow = ms * Math.ceil((now + ms) / ms);
+  },
+};
 
 const interval = setInterval(
   () => {

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -16,10 +16,6 @@ const approximateTime = {
 
     return __1;
   },
-  set now (nextNow) {
-    __0 = nextNow;
-    __1 = ms * Math.ceil((__0 + ms) / ms);
-  },
 };
 
 const interval = setInterval(step, ms);

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -22,12 +22,7 @@ const approximateTime = {
   },
 };
 
-const interval = setInterval(
-  () => {
-    step();
-  },
-  ms,
-);
+const interval = setInterval(step, ms);
 
 interval.unref();
 

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -11,14 +11,14 @@ Object.defineProperty(
   approximateTime,
   'now',
   {
-    get: () => {
+    get () {
       if (now < maxNow) {
         return now++;
       }
 
       return maxNow;
     },
-    set: (nextNow) => {
+    set (nextNow) {
       now = nextNow;
       maxNow = ms * Math.ceil((now + ms) / ms);
     },

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -1,19 +1,19 @@
 const ms = 50;
 
-let now = ms * Math.ceil(Date.now() / ms);
-let maxNow = ms * Math.ceil((now + ms) / ms);
+let __0 = ms * Math.ceil(Date.now() / ms);
+let __1 = ms * Math.ceil((__0 + ms) / ms);
 
 const approximateTime = {
   get now () {
-    if (now < maxNow) {
-      return now++;
+    if (__0 < __1) {
+      return __0++;
     }
 
-    return maxNow;
+    return __1;
   },
   set now (nextNow) {
-    now = nextNow;
-    maxNow = ms * Math.ceil((now + ms) / ms);
+    __0 = nextNow;
+    __1 = ms * Math.ceil((__0 + ms) / ms);
   },
 };
 

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -32,9 +32,7 @@ const interval = setInterval(
   ms,
 );
 
-if (interval && interval.unref) {
-  interval.unref();
-}
+interval.unref();
 
 export {
   approximateTime,

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -4,26 +4,18 @@ let now = ms * Math.ceil(Date.now() / ms);
 let maxNow = ms * Math.ceil((now + ms) / ms);
 
 const approximateTime = {
-  now,
-};
-
-Object.defineProperty(
-  approximateTime,
-  'now',
-  {
-    get () {
+    get now () {
       if (now < maxNow) {
         return now++;
       }
 
       return maxNow;
     },
-    set (nextNow) {
+    set now (nextNow) {
       now = nextNow;
       maxNow = ms * Math.ceil((now + ms) / ms);
     },
-  },
-);
+  };
 
 const interval = setInterval(
   () => {

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -3,6 +3,11 @@ const ms = 50;
 let __0 = ms * Math.ceil(Date.now() / ms);
 let __1 = ms * Math.ceil((__0 + ms) / ms);
 
+const step = function () {
+  __0 = ms * Math.ceil(Date.now() / ms);
+  __1 = ms * Math.ceil((__0 + ms) / ms);
+}
+
 const approximateTime = {
   get now () {
     if (__0 < __1) {
@@ -19,7 +24,7 @@ const approximateTime = {
 
 const interval = setInterval(
   () => {
-    approximateTime.now = ms * Math.ceil(Date.now() / ms);
+    step();
   },
   ms,
 );

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -1,5 +1,7 @@
-let now = 50 * Math.ceil(Date.now() / 50);
-let maxNow = 50 * Math.ceil((now + 50) / 50);
+const ms = 50;
+
+let now = ms * Math.ceil(Date.now() / ms);
+let maxNow = ms * Math.ceil((now + ms) / ms);
 
 const approximateTime = {
   now,
@@ -18,16 +20,16 @@ Object.defineProperty(
     },
     set: (nextNow) => {
       now = nextNow;
-      maxNow = 50 * Math.ceil((now + 50) / 50);
+      maxNow = ms * Math.ceil((now + ms) / ms);
     },
   },
 );
 
 const interval = setInterval(
   () => {
-    approximateTime.now = 50 * Math.ceil(Date.now() / 50);
+    approximateTime.now = ms * Math.ceil(Date.now() / ms);
   },
-  50,
+  ms,
 );
 
 if (interval && interval.unref) {

--- a/src/approximateNow.ts
+++ b/src/approximateNow.ts
@@ -1,27 +1,17 @@
 const ms = 50;
 
-let __0 = ms * Math.ceil(Date.now() / ms);
-let __1 = ms * Math.ceil((__0 + ms) / ms);
+let __0 = NaN;
+let __1 = NaN;
 
 const step = function () {
   __0 = ms * Math.ceil(Date.now() / ms);
-  __1 = ms * Math.ceil((__0 + ms) / ms);
+  __1 = ms + __0;
+};
+
+void step();
+
+setInterval(step, ms).unref();
+
+export function now() {
+  return __0 < __1 ? __0++ : __1;
 }
-
-const approximateTime = {
-  get now () {
-    if (__0 < __1) {
-      return __0++;
-    }
-
-    return __1;
-  },
-};
-
-const interval = setInterval(step, ms);
-
-interval.unref();
-
-export {
-  approximateTime,
-};

--- a/test/approximate-now/approximateNow.ts
+++ b/test/approximate-now/approximateNow.ts
@@ -4,74 +4,74 @@
 import test from 'ava';
 import delay from 'delay';
 import {
-  approximateTime,
+  now,
 } from '../../src/approximateNow';
 
 test('updates every 50ms', async (t) => {
-  const firstTime = approximateTime.now;
+  const firstTime = now();
 
   await delay(100);
 
-  t.true(firstTime < approximateTime.now);
+  t.true(firstTime < now());
 });
 
 test('increments time after every measurement', (t) => {
-  t.not(approximateTime.now, approximateTime.now);
+  t.not(now(), now());
 });
 
 test('does not increment beyond 50', (t) => {
   const times = [];
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
-  times.push(approximateTime.now);
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
+  times.push(now());
 
   t.is(times[times.length - 1], times[times.length - 2]);
 });

--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -4,7 +4,7 @@ import {
   Suite,
 } from 'benchmark';
 import {
-  approximateTime,
+  now,
 } from '../src/approximateNow';
 
 (() => {
@@ -25,10 +25,9 @@ import {
   );
 
   suite.add(
-    'approximateTime.now',
+    'now()',
     () => {
-      // eslint-disable-next-line no-unused-expressions
-      approximateTime.now;
+      now();
     },
   );
 


### PR DESCRIPTION
### Comparison

#### 6ea8bab (master)

```console
$ npm run benchmark 

> approximate-now@1.0.0 benchmark
> ROARR_LOG=true ts-node --transpile-only test/benchmark.ts

Date.now() x 18,871,650 ops/sec ±1.11% (92 runs sampled)
approximateTime.now x 71,874,298 ops/sec ±1.02% (93 runs sampled)
```

#### f8bd79e

```console
$ npm run benchmark 

> approximate-now@1.0.0 benchmark
> ROARR_LOG=true ts-node --transpile-only test/benchmark.ts

Date.now() x 19,437,324 ops/sec ±0.54% (92 runs sampled)
now() x 190,412,333 ops/sec ±0.59% (95 runs sampled)
```

Closes #2
Closes #4